### PR TITLE
fix: deploy to OpenShift (remove volumeMount)

### DIFF
--- a/openshift/admin-console.app.yaml
+++ b/openshift/admin-console.app.yaml
@@ -107,10 +107,6 @@ objects:
               cpu: 400m
               memory: 1.5Gi
           terminationMessagePath: /dev/termination-log
-          volumeMounts:
-          - mountPath: /etc/fabric8/
-            name: admin-console-configs
-            readOnly: true
         dnsPolicy: ClusterFirst
         restartPolicy: Always
         securityContext: {}


### PR DESCRIPTION
causes error since volume was already removed

updates #29

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>