### PR TITLE
fix: ignore empty/missing sentry_dsn for now

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -673,6 +673,7 @@
     "github.com/goadesign/goa/middleware",
     "github.com/goadesign/goa/middleware/gzip",
     "github.com/goadesign/goa/middleware/security/jwt",
+    "github.com/gojuno/minimock",
     "github.com/gojuno/minimock/cmd/minimock",
     "github.com/golang/lint/golint",
     "github.com/google/gops/agent",

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // String returns the current configuration as a string
@@ -92,7 +92,8 @@ func New() *Configuration {
 		c.appendDefaultConfigErrorMessage("Auth service url is localhost")
 	}
 	if c.GetSentryDSN() == "" {
-		c.appendDefaultConfigErrorMessage("Sentry DSN is empty")
+		// c.appendDefaultConfigErrorMessage("Sentry DSN is empty")
+		log.Error("missing 'sentry_dsn' environment variable")
 	}
 	if c.GetPostgresPassword() == defaultDBPassword {
 		c.appendDefaultConfigErrorMessage("default DB password is used")

--- a/configuration/configuration_blackbox_test.go
+++ b/configuration/configuration_blackbox_test.go
@@ -76,21 +76,22 @@ func TestConfiguration(t *testing.T) {
 			assert.Equal(t, err.Error(), "invalid Auth service url (missing scheme?)")
 		})
 
-		t.Run("error when using empty Sentry DSN only", func(t *testing.T) {
-			// given
-			unsetenvs := setenvs(envvars{
-				"ADMIN_AUTH_URL":               "http://auth",
-				"ADMIN_POSTGRES_PASSWORD":      "anothersecretpassword",
-				"ADMIN_DEVELOPER_MODE_ENABLED": "false",
-			})
-			defer unsetenvs()
-			// when
-			config := configuration.New()
-			// then
-			err := config.DefaultConfigurationError()
-			require.Error(t, err)
-			assert.Equal(t, err.Error(), "Sentry DSN is empty")
-		})
+		// TODO: restore 
+		// t.Run("error when using empty Sentry DSN only", func(t *testing.T) {
+		// 	// given
+		// 	unsetenvs := setenvs(envvars{
+		// 		"ADMIN_AUTH_URL":               "http://auth",
+		// 		"ADMIN_POSTGRES_PASSWORD":      "anothersecretpassword",
+		// 		"ADMIN_DEVELOPER_MODE_ENABLED": "false",
+		// 	})
+		// 	defer unsetenvs()
+		// 	// when
+		// 	config := configuration.New()
+		// 	// then
+		// 	err := config.DefaultConfigurationError()
+		// 	require.Error(t, err)
+		// 	assert.Equal(t, err.Error(), "Sentry DSN is empty")
+		// })
 
 		t.Run("no error when all envs set", func(t *testing.T) {
 			// given


### PR DESCRIPTION
this would avoid deployement failures on preview, until the
missing `sentry_dsn` env var has been added in the configmap/secrets

fixes #42

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>