### PR TITLE
feat(fabric8-services/fabric8-tenant#731): support parametrized GET request to api/tenants/update

### DIFF
--- a/controller/tenant_update.go
+++ b/controller/tenant_update.go
@@ -52,7 +52,7 @@ func (c *TenantUpdateController) Show(ctx *app.ShowTenantUpdateContext) error {
 		return appl.AuditLogs().Create(ctx, &auditlog.AuditLog{
 			EventTypeID: auditlog.ShowTenantUpdate,
 			IdentityID:  identityID,
-			EventParams: auditlog.EventParams{},
+			EventParams: eventParams,
 		})
 	})
 	if err != nil {

--- a/controller/tenant_update.go
+++ b/controller/tenant_update.go
@@ -42,6 +42,13 @@ func (c *TenantUpdateController) Show(ctx *app.ShowTenantUpdateContext) error {
 		return app.JSONErrorResponse(ctx, errors.NewUnauthorizedError("invalid or missing authorization token"))
 	}
 	err = application.Transactional(c.db, func(appl application.Application) error {
+		eventParams := auditlog.EventParams{}
+		if ctx.ClusterURL != nil {
+			eventParams["clusterURL"] = *ctx.ClusterURL
+		}
+		if ctx.EnvType != nil {
+			eventParams["envType"] = *ctx.EnvType
+		}
 		return appl.AuditLogs().Create(ctx, &auditlog.AuditLog{
 			EventTypeID: auditlog.ShowTenantUpdate,
 			IdentityID:  identityID,

--- a/controller/tenant_update_blackbox_test.go
+++ b/controller/tenant_update_blackbox_test.go
@@ -74,7 +74,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchHeader("Authorization", authzHeader).
 				Reply(http.StatusOK).BodyString(`{"data":"whatever"}`)
 			// when
-			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, nil, nil, &authzHeader)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
 		})
@@ -128,7 +128,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchHeader("Authorization", authzHeader).
 				Reply(http.StatusUnauthorized)
 			// when
-			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, nil, nil, &authzHeader)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
 		})
@@ -145,7 +145,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchHeader("Authorization", authzHeader).
 				Reply(http.StatusInternalServerError)
 			// when
-			apptest.ShowTenantUpdateInternalServerError(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			apptest.ShowTenantUpdateInternalServerError(t, ctx, svc, ctrl, nil, nil, &authzHeader)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
 		})

--- a/controller/tenant_update_blackbox_test.go
+++ b/controller/tenant_update_blackbox_test.go
@@ -95,7 +95,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchParam("env_type", envType).
 				Reply(http.StatusOK).BodyString(`{"data":"whatever"}`)
 			// when
-			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &cluster, &envType, &authzHeader)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{
 				"clusterURL": cluster,
@@ -319,7 +319,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestStopTenantUpdate() {
 				Reply(http.StatusUnauthorized)
 			ctx := context.Background() // context is missing a JWT
 			// when/then
-			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, nil)
+			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, nil, nil, nil)
 		})
 
 		t.Run("unauthorized", func(t *testing.T) {

--- a/controller/tenant_update_blackbox_test.go
+++ b/controller/tenant_update_blackbox_test.go
@@ -62,20 +62,46 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 	defer gock.OffAll()
 
 	s.T().Run("ok", func(t *testing.T) {
-		// given
-		ctx, identity, err := testauth.EmbedUserTokenInContext(context.Background(), testauth.NewIdentity())
-		require.NoError(t, err)
-		tk := goajwt.ContextJWT(ctx)
-		require.NotNil(t, tk)
-		authzHeader := fmt.Sprintf("Bearer %s", tk.Raw)
-		gock.New("http://test-tenant").
-			Get("/api/update").
-			MatchHeader("Authorization", authzHeader).
-			Reply(http.StatusOK).BodyString(`{"data":"whatever"}`)
-		// when
-		apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &authzHeader)
-		// then check that an audit record was created
-		assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
+		t.Run("all clusters all envs", func(t *testing.T) {
+			// given
+			ctx, identity, err := testauth.EmbedUserTokenInContext(context.Background(), testauth.NewIdentity())
+			require.NoError(t, err)
+			tk := goajwt.ContextJWT(ctx)
+			require.NotNil(t, tk)
+			authzHeader := fmt.Sprintf("Bearer %s", tk.Raw)
+			gock.New("http://test-tenant").
+				Get("/api/update").
+				MatchHeader("Authorization", authzHeader).
+				Reply(http.StatusOK).BodyString(`{"data":"whatever"}`)
+			// when
+			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			// then check that an audit record was created
+			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
+		})
+		t.Run("single clusters single env", func(t *testing.T) {
+			// given
+			ctx, identity, err := testauth.EmbedUserTokenInContext(context.Background(), testauth.NewIdentity())
+			require.NoError(t, err)
+			tk := goajwt.ContextJWT(ctx)
+			require.NotNil(t, tk)
+			authzHeader := fmt.Sprintf("Bearer %s", tk.Raw)
+
+			cluster := "cluster1"
+			envType := "stage"
+			gock.New("http://test-tenant").
+				Get("/api/update").
+				MatchHeader("Authorization", authzHeader).
+				MatchParam("cluster_url", cluster).
+				MatchParam("env_type", envType).
+				Reply(http.StatusOK).BodyString(`{"data":"whatever"}`)
+			// when
+			apptest.ShowTenantUpdateOK(t, ctx, svc, ctrl, &authzHeader, nil, nil)
+			// then check that an audit record was created
+			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{
+				"clusterURL": cluster,
+				"envType":    envType,
+			})
+		})
 	})
 
 	s.T().Run("failures", func(t *testing.T) {
@@ -87,7 +113,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				Reply(http.StatusUnauthorized)
 			ctx := context.Background() // context is missing a JWT
 			// when/then
-			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, nil)
+			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, nil, nil, nil)
 		})
 
 		t.Run("unauthorized", func(t *testing.T) {
@@ -102,7 +128,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchHeader("Authorization", authzHeader).
 				Reply(http.StatusUnauthorized)
 			// when
-			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, &authzHeader)
+			apptest.ShowTenantUpdateUnauthorized(t, ctx, svc, ctrl, &authzHeader, nil, nil)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
 		})
@@ -119,7 +145,7 @@ func (s *TenantUpdateControllerBlackboxTestSuite) TestShowTenantUpdate() {
 				MatchHeader("Authorization", authzHeader).
 				Reply(http.StatusInternalServerError)
 			// when
-			apptest.ShowTenantUpdateInternalServerError(t, ctx, svc, ctrl, &authzHeader)
+			apptest.ShowTenantUpdateInternalServerError(t, ctx, svc, ctrl, &authzHeader, nil, nil)
 			// then check that an audit record was created
 			assertAuditLog(t, s.DB, *identity, auditlog.ShowTenantUpdate, auditlog.EventParams{})
 		})

--- a/design/tenant_update.go
+++ b/design/tenant_update.go
@@ -16,8 +16,16 @@ var _ = a.Resource("tenant_update", func() {
 		a.Headers(func() {
 			a.Header("Authorization", d.String, "the authorization header")
 		})
+		a.Params(func() {
+			a.Param("cluster_url", d.String, "the URL of the OSO cluster the number of outdated tenants should be limited to")
+			a.Param("env_type", d.String, "environment type the number of outdated tenants should be limited to", func() {
+				a.Enum("user", "che", "jenkins", "stage", "run")
+			})
+		})
+
 		a.Description("Get information about last/ongoing update.")
 		a.Response(d.OK) // here we don't specify a media type, because we're just proxying to `tenant`
+		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 	})


### PR DESCRIPTION
support parametrized GET request to `api/tenants/update`

adds support for: fabric8-services/fabric8-tenant#731

is blocked by: https://github.com/fabric8-services/fabric8-tenant/pull/732