### PR TITLE
feat: endpoint to create audit logs

### DIFF
--- a/auditlog/event_types.go
+++ b/auditlog/event_types.go
@@ -6,6 +6,13 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+const (
+	// UserDeactivationNotificationEvent the type name for a user deactivation notification
+	UserDeactivationNotificationEvent = "user_deactivation_notification"
+	// UserDeactivationEvent the type name for a user deactivation
+	UserDeactivationEvent = "user_deactivation"
+)
+
 // UserSearch the UUID of the event for the "user search" action
 var UserSearch uuid.UUID
 
@@ -18,8 +25,19 @@ var StartTenantUpdate uuid.UUID
 // StopTenantUpdate the UUID of the event for the "stop tenant update" action
 var StopTenantUpdate uuid.UUID
 
+// UserDeactivationNotification the UUID of the event when a user is notified before account deactivation
+var UserDeactivationNotification uuid.UUID
+
+// UserDeactivation the UUID of the event when a user account is deactivated
+var UserDeactivation uuid.UUID
+
+// EventTypes the event types indexed buy their name. At least, those that can be created from an endpoint
+var EventTypes map[string]uuid.UUID
+
 func init() {
 	var err error
+	EventTypes = map[string]uuid.UUID{}
+
 	UserSearch, err = uuid.FromString("7aea0277-d6fa-4df9-8224-a27fa4096ec7")
 	if err != nil {
 		panic(fmt.Sprintf("UserSearch event type ID is not an UUID: %v", err))
@@ -36,4 +54,16 @@ func init() {
 	if err != nil {
 		panic(fmt.Sprintf("StopTenantUpdate event type ID is not an UUID: %v", err))
 	}
+
+	UserDeactivationNotification, err = uuid.FromString("9f924fc3-403b-4167-b20c-a543adc4ff3c")
+	if err != nil {
+		panic(fmt.Sprintf("UserDeactivationNotification event type ID is not an UUID: %v", err))
+	}
+	EventTypes[UserDeactivationNotificationEvent] = UserDeactivationNotification
+	UserDeactivation, err = uuid.FromString("777ede15-4b18-4720-bada-1519d1915f2e")
+	if err != nil {
+		panic(fmt.Sprintf("UserDeactivation event type ID is not an UUID: %v", err))
+	}
+	EventTypes[UserDeactivationEvent] = UserDeactivation
+
 }

--- a/controller/audit_log.go
+++ b/controller/audit_log.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"github.com/fabric8-services/admin-console/app"
+	"github.com/fabric8-services/admin-console/application"
+	"github.com/fabric8-services/admin-console/auditlog"
+	"github.com/fabric8-services/fabric8-common/auth"
+	"github.com/fabric8-services/fabric8-common/errors"
+	"github.com/fabric8-services/fabric8-common/log"
+	"github.com/goadesign/goa"
+)
+
+// AuditLogsController implements the auditlogs resource.
+type AuditLogsController struct {
+	*goa.Controller
+	db application.DB
+}
+
+// NewAuditLogsController creates a auditlogs controller.
+func NewAuditLogsController(service *goa.Service, db application.DB) *AuditLogsController {
+	return &AuditLogsController{
+		Controller: service.NewController("AuditLogsController"),
+		db:         db,
+	}
+}
+
+// Create runs the create action.
+func (c *AuditLogsController) Create(ctx *app.CreateAuditLogContext) error {
+	// check the token and make sure it belongs to `auth`
+	if !auth.IsSpecificServiceAccount(ctx, auth.Auth) {
+		return app.JSONErrorResponse(ctx, errors.NewUnauthorizedError("invalid or missing authorization token"))
+	}
+	// lookup the event type ID
+	eventTypeID, found := auditlog.EventTypes[ctx.Payload.Data.Attributes.EventType]
+	if !found {
+		return app.JSONErrorResponse(ctx, errors.NewBadParameterError("event_type", ctx.Payload.Data.Attributes.EventType))
+	}
+	log.Info(ctx, map[string]interface{}{
+		"username": ctx.Username,
+	}, "creating audit log for user")
+	err := application.Transactional(c.db, func(appl application.Application) error {
+		return appl.AuditLogs().Create(ctx, &auditlog.AuditLog{
+			Username:    ctx.Username,
+			EventTypeID: eventTypeID,
+			EventParams: ctx.Payload.Data.Attributes.EventParams,
+		})
+	})
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"err":      err,
+			"username": ctx.Username,
+		}, "unable to record the auditlog for user")
+		return app.JSONErrorResponse(ctx, err)
+	}
+
+	return ctx.NoContent()
+}

--- a/controller/audit_log_blackbox_test.go
+++ b/controller/audit_log_blackbox_test.go
@@ -1,0 +1,129 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fabric8-services/admin-console/app"
+	apptest "github.com/fabric8-services/admin-console/app/test"
+	"github.com/fabric8-services/admin-console/application"
+	"github.com/fabric8-services/admin-console/auditlog"
+	"github.com/fabric8-services/admin-console/configuration"
+	"github.com/fabric8-services/admin-console/controller"
+	"github.com/fabric8-services/fabric8-common/auth"
+	"github.com/fabric8-services/fabric8-common/resource"
+	testauth "github.com/fabric8-services/fabric8-common/test/auth"
+	testsuite "github.com/fabric8-services/fabric8-common/test/suite"
+	"github.com/goadesign/goa"
+
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type AuditLogsControllerBlackboxTestSuite struct {
+	testsuite.DBTestSuite
+	app *application.GormApplication
+}
+
+func TestAuditLogs(t *testing.T) {
+	resource.Require(t, resource.Database)
+	config := configuration.New()
+	suite.Run(t, &AuditLogsControllerBlackboxTestSuite{DBTestSuite: testsuite.NewDBTestSuite(config)})
+}
+
+func (s *AuditLogsControllerBlackboxTestSuite) SetupSuite() {
+	s.DBTestSuite.SetupSuite()
+	s.app = application.NewGormApplication(s.DB)
+}
+
+func (s *AuditLogsControllerBlackboxTestSuite) TestCreateAuditLog() {
+
+	// given
+	svc := goa.New("auditlogs")
+	ctrl := controller.NewAuditLogsController(svc, s.app)
+	ctx, err := testauth.EmbedServiceAccountTokenInContext(context.Background(), &testauth.Identity{
+		Username: auth.Auth,
+		ID:       uuid.NewV4(),
+	})
+	require.NoError(s.T(), err)
+	s.Run("success", func() {
+		// when
+		eventParams := auditlog.EventParams{
+			"notification_deactivation": time.Now().Format("2006-01-02:15:04:05"),
+			"scheduled_deactivation":    time.Now().Add(time.Hour * 24 * 7).Format("2006-01-02:15:04:05"),
+		}
+		apptest.CreateAuditLogNoContent(s.T(), ctx, svc, ctrl, "username", &app.CreateAuditLogPayload{
+			Data: &app.CreateAuditLogData{
+				Type: "audit_logs",
+				Attributes: &app.CreateAuditLogDataAttributes{
+					EventType:   auditlog.UserDeactivationEvent,
+					EventParams: eventParams,
+				},
+			},
+		})
+		// then check that the data was collected
+		records, total, err := auditlog.NewRepository(s.DB).ListByUsername(context.Background(), "username", 0, 5)
+		require.NoError(s.T(), err)
+		require.Equal(s.T(), 1, total)
+		record := records[0]
+		assert.Equal(s.T(), auditlog.UserDeactivation, record.EventTypeID)
+		assert.Equal(s.T(), eventParams, record.EventParams)
+	})
+
+	s.Run("failures", func() {
+		s.Run("bad request", func() {
+			s.Run("invalid event type", func() {
+				// when/then
+				apptest.CreateAuditLogBadRequest(s.T(), ctx, svc, ctrl, "username", &app.CreateAuditLogPayload{
+					Data: &app.CreateAuditLogData{
+						Type: "audit_logs",
+						Attributes: &app.CreateAuditLogDataAttributes{
+							EventType:   "invalid",
+							EventParams: map[string]interface{}{},
+						},
+					},
+				})
+			})
+		})
+
+		s.Run("unauthorized", func() {
+			s.Run("missing token", func() {
+				// when/then
+				apptest.CreateAuditLogUnauthorized(s.T(), context.Background(), svc, ctrl, "username", &app.CreateAuditLogPayload{
+					Data: &app.CreateAuditLogData{
+						Type: "audit_logs",
+						Attributes: &app.CreateAuditLogDataAttributes{
+							EventType: "user_deactivation_notification",
+							EventParams: map[string]interface{}{
+								"notification_deactivation": time.Now().Format("2006-01-02:15:04:05"),
+								"scheduled_deactivation":    time.Now().Add(time.Hour * 24 * 7).Format("2006-01-02:15:04:05"),
+							},
+						},
+					},
+				})
+			})
+
+			s.Run("invalid token", func() {
+				// given
+				ctx, _, err := testauth.EmbedUserTokenInContext(context.Background(), testauth.NewIdentity())
+				require.NoError(s.T(), err)
+				// when/then
+				apptest.CreateAuditLogUnauthorized(s.T(), ctx, svc, ctrl, "username", &app.CreateAuditLogPayload{
+					Data: &app.CreateAuditLogData{
+						Type: "audit_logs",
+						Attributes: &app.CreateAuditLogDataAttributes{
+							EventType: "user_deactivation_notification",
+							EventParams: map[string]interface{}{
+								"notification_deactivation": time.Now().Format("2006-01-02:15:04:05"),
+								"scheduled_deactivation":    time.Now().Add(time.Hour * 24 * 7).Format("2006-01-02:15:04:05"),
+							},
+						},
+					},
+				})
+			})
+		})
+	})
+}

--- a/design/audit_log.go
+++ b/design/audit_log.go
@@ -1,0 +1,58 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var _ = a.Resource("audit_log", func() {
+
+	a.BasePath("/auditlogs")
+
+	a.Action("create", func() {
+		a.Security("jwt")
+		a.Routing(
+			a.POST("users/:username"),
+		)
+		a.Description("Add an auditlog for a user")
+		a.Params(func() {
+			a.Param("username", d.String)
+			a.Required("username")
+		})
+		a.Payload(createAuditLog)
+		a.Response(d.NoContent)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+	})
+})
+
+var createAuditLog = a.MediaType("application/vnd.createauditlog+json", func() {
+	a.UseTrait("jsonapi-media-type")
+	a.TypeName("CreateAuditLog")
+	a.Description("Create an auditlog")
+	a.Attributes(func() {
+		a.Attribute("data", createAuditLogData)
+		a.Required("data")
+	})
+	a.View("default", func() {
+		a.Attribute("data")
+		a.Required("data")
+	})
+})
+
+// createAuditLogData represents the data of an audit log to create for a user
+var createAuditLogData = a.Type("CreateAuditLogData", func() {
+	a.Attribute("type", d.String, "type of the audit log", func() {
+		a.Enum("audit_logs")
+	})
+	a.Attribute("attributes", createAuditLogDataAttributes, "Attributes of the audit log. ")
+	a.Attribute("links", genericLinks)
+	a.Required("type", "attributes")
+})
+
+var createAuditLogDataAttributes = a.Type("CreateAuditLogDataAttributes", func() {
+	a.Attribute("event_type", d.String, "the type of event")
+	a.Attribute("event_params", a.HashOf(d.String, d.Any), "a generic map holding the params of the event to log")
+	a.Required("event_type", "event_params")
+})

--- a/design/tenant_update.go
+++ b/design/tenant_update.go
@@ -44,7 +44,6 @@ var _ = a.Resource("tenant_update", func() {
 				a.Enum("user", "che", "jenkins", "stage", "run")
 			})
 		})
-
 		a.Description("Start new cluster-wide update.")
 		a.Response(d.Accepted)
 		a.Response(d.Conflict) // here we don't specify a media type, because we're just proxying to `tenant`

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -21,6 +21,7 @@ func Steps() Scripts {
 		{"001-audit-log.sql"},
 		{"002-tenant-updates-event-types.sql"},
 		{"003-audit-log-with-username.sql"},
+		{"004-deactivation-event-types.sql"},
 	}
 }
 

--- a/migration/sql-files/004-deactivation-event-types.sql
+++ b/migration/sql-files/004-deactivation-event-types.sql
@@ -1,0 +1,2 @@
+insert into event_type (event_type_id, name) values ('9f924fc3-403b-4167-b20c-a543adc4ff3c', 'user_deactivation_notification');
+insert into event_type (event_type_id, name) values ('777ede15-4b18-4720-bada-1519d1915f2e', 'user_deactiuvation');


### PR DESCRIPTION
restricted to `auth` service, and to `user_deactivation`
and `user_deactivation_notification` type of messages.

fixes #ODC759

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>