### PR TITLE
refactor: change endpoint template URL to list events

### DIFF
--- a/controller/audit_log_blackbox_test.go
+++ b/controller/audit_log_blackbox_test.go
@@ -206,12 +206,12 @@ func (s *AuditLogsControllerBlackboxTestSuite) TestListAuditLogs() {
 			assert.Nil(s.T(), result.Data[0].Attributes.EventParams)
 			// verify links
 			require.NotNil(s.T(), result.Links.First)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=1", targetUser), *result.Links.First)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=1", targetUser), *result.Links.First)
 			require.Nil(s.T(), result.Links.Prev)
 			require.NotNil(s.T(), result.Links.Next)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Next)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Next)
 			require.NotNil(s.T(), result.Links.Last)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Last)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Last)
 			// verify meta
 			require.NotNil(s.T(), result.Meta)
 			assert.Equal(s.T(), result.Meta.TotalCount, 2)
@@ -233,12 +233,12 @@ func (s *AuditLogsControllerBlackboxTestSuite) TestListAuditLogs() {
 			assert.Equal(s.T(), result.Meta.TotalCount, 2)
 			// verify links
 			require.NotNil(s.T(), result.Links.First)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=1", targetUser), *result.Links.First)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=1", targetUser), *result.Links.First)
 			require.NotNil(s.T(), result.Links.Prev)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=1", targetUser), *result.Links.Prev)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=1", targetUser), *result.Links.Prev)
 			require.Nil(s.T(), result.Links.Next)
 			require.NotNil(s.T(), result.Links.Last)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Last)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=1&page[size]=1", targetUser), *result.Links.Last)
 			// also, verify that an event was logged on behalf of the requesting user
 			s.assertRequesterLogs(requestingUser, targetUser)
 		})
@@ -257,11 +257,11 @@ func (s *AuditLogsControllerBlackboxTestSuite) TestListAuditLogs() {
 			assert.Equal(s.T(), result.Meta.TotalCount, 2)
 			// verify links
 			require.NotNil(s.T(), result.Links.First)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=10", targetUser), *result.Links.First)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=10", targetUser), *result.Links.First)
 			require.Nil(s.T(), result.Links.Prev)
 			require.Nil(s.T(), result.Links.Next)
 			require.NotNil(s.T(), result.Links.Last)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=10", targetUser), *result.Links.Last)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=10", targetUser), *result.Links.Last)
 			// also, verify that an event was logged on behalf of the requesting user
 			s.assertRequesterLogs(requestingUser, targetUser)
 		})
@@ -279,11 +279,11 @@ func (s *AuditLogsControllerBlackboxTestSuite) TestListAuditLogs() {
 			assert.Equal(s.T(), result.Meta.TotalCount, 2)
 			// verify links
 			require.NotNil(s.T(), result.Links.First)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=10", targetUser), *result.Links.First)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=10", targetUser), *result.Links.First)
 			require.Nil(s.T(), result.Links.Prev)
 			require.Nil(s.T(), result.Links.Next)
 			require.NotNil(s.T(), result.Links.Last)
-			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/%s?page[start]=0&page[size]=10", targetUser), *result.Links.Last)
+			assert.Equal(s.T(), fmt.Sprintf("http:///api/auditlogs/users/%s?page[start]=0&page[size]=10", targetUser), *result.Links.Last)
 			// also, verify that an event was logged on behalf of the requesting user
 			s.assertRequesterLogs(requestingUser, targetUser)
 		})

--- a/design/audit_log.go
+++ b/design/audit_log.go
@@ -29,7 +29,7 @@ var _ = a.Resource("audit_log", func() {
 	a.Action("list_for_user", func() {
 		a.Security("jwt")
 		a.Routing(
-			a.GET("/:username"),
+			a.GET("users/:username"),
 		)
 		a.Description("List audit logs for a given user")
 		a.Params(func() {


### PR DESCRIPTION
changed from `GET /api/auditlogs/:username` to `GET /api/auditlogs/users/:username` to match with the existing `POST `/api/auditlogs/users/:username` endpoint

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>